### PR TITLE
Fit coverage with amis

### DIFF
--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -77,7 +77,7 @@ def alterMDACoverage(MDAData, coverage):
     ----------
     MDAData
         A list of MDA's to be done with date and coverage of the MDA included. 
-        The coverage is given by the 4th value so we update the [3] position.
+        The coverage is given by the 4th value within each MDA of MDAData so we update the [3] position.
     coverage    
         The new coverage level for each MDA
 

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -70,6 +70,24 @@ def setup(initial_prevalence: float):
         VaccData,
     )
 
+def alterMDACoverage(MDAData, coverage):
+    """ update the coverage of each MDA for a run to be a given value.
+
+    Parameters
+    ----------
+    MDAData
+        A list of MDA's to be done with date and coverage of the MDA included
+    coverage    
+        The new coverage level for each MDA
+
+    Returns
+    -------
+    function
+        MDAData with updated coverage value
+    """
+    for MDA in MDAData:
+        MDA[3] = coverage
+    return MDAData
 
 def build_transmission_model(
         fitting_points: list[int],
@@ -120,13 +138,13 @@ def build_transmission_model(
                 demog=demog,
                 beta=beta,
                 MDA_times=MDA_times,
-                MDAData=MDAData,
+                MDAData=alterMDACoverage(MDAData, coverage),
                 vacc_times=vacc_times,
                 VaccData=VaccData,
                 outputTimes=outputTimes,
                 index=i,
             )
-            for i, (seed, beta) in enumerate(params)
+            for i, (seed, beta, coverage) in enumerate(params)
         )
         # Get the prevalence from the returned values dictionary
         # Could probably also compute it again here.

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -76,7 +76,8 @@ def alterMDACoverage(MDAData, coverage):
     Parameters
     ----------
     MDAData
-        A list of MDA's to be done with date and coverage of the MDA included
+        A list of MDA's to be done with date and coverage of the MDA included. 
+        The coverage is given by the 4th value so we update the [3] position.
     coverage    
         The new coverage level for each MDA
 


### PR DESCRIPTION
We want to be able to fit the coverage of the MDA's for trachoma within the amis algorithm. 

To do this we assume that the `params` variable, which specifies the amis parameters for a given run, will contain the `seed` and `beta` and will also contain a `coverage` value. This `coverage` value specifies the coverage for the MDA's for that model run. The `seed`, `beta` and `coverage` values are iterated when the trachoma model is run and the `MDAData` will be changed to reflect this coverage.

We are assuming that only one coverage value will be specified for each run, so all historical MDA's are assumed to have had the same coverage.