### PR TITLE
Fit coverage with amis

### DIFF
--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -49,18 +49,17 @@ def setup_vaccine(cov_filepath, burnin):
 
 def setup(initial_prevalence: float):
 
-    MDA_times, MDAData = setup_mda("scen2c.csv", sim_params["burnin"])
-    vacc_times, VaccData = setup_vaccine("scen2c.csv", sim_params["burnin"])
-    sim_params["N_MDA"] = len(MDA_times)
-    sim_params["N_Vaccines"] = len(vacc_times)
-     
-    vals = Set_inits(parameters, demog, sim_params, MDAData, np.random.get_state())
+    vals = Set_inits(parameters, demog, sim_params, np.random.get_state())
     ids = random.sample(range(parameters["N"]), k=int(initial_prevalence * parameters["N"]))
     vals["IndI"][ids] = 1
     vals["T_latent"][ids] = vals["Ind_latent"][ids]
     vals["No_Inf"][ids] = 1
 
-    
+    MDA_times, MDAData = setup_mda("scen2c.csv", sim_params["burnin"])
+    vacc_times, VaccData = setup_vaccine("scen2c.csv", sim_params["burnin"])
+    sim_params["N_MDA"] = len(MDA_times)
+    sim_params["N_Vaccines"] = len(vacc_times)
+     
 
     return (
         vals,

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -48,16 +48,19 @@ def setup_vaccine(cov_filepath, burnin):
 
 
 def setup(initial_prevalence: float):
-    vals = Set_inits(parameters, demog, sim_params, np.random.get_state())
-    ids = random.sample(range(parameters["N"]), k=int(initial_prevalence * parameters["N"]))
-    vals["IndI"][ids] = 1
-    vals["T_latent"][ids] = vals["Ind_latent"][ids]
-    vals["No_Inf"][ids] = 1
 
     MDA_times, MDAData = setup_mda("scen2c.csv", sim_params["burnin"])
     vacc_times, VaccData = setup_vaccine("scen2c.csv", sim_params["burnin"])
     sim_params["N_MDA"] = len(MDA_times)
     sim_params["N_Vaccines"] = len(vacc_times)
+     
+    vals = Set_inits(parameters, demog, sim_params, MDAData, np.random.get_state())
+    ids = random.sample(range(parameters["N"]), k=int(initial_prevalence * parameters["N"]))
+    vals["IndI"][ids] = 1
+    vals["T_latent"][ids] = vals["Ind_latent"][ids]
+    vals["No_Inf"][ids] = 1
+
+    
 
     return (
         vals,

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -48,7 +48,6 @@ def setup_vaccine(cov_filepath, burnin):
 
 
 def setup(initial_prevalence: float):
-
     vals = Set_inits(parameters, demog, sim_params, np.random.get_state())
     ids = random.sample(range(parameters["N"]), k=int(initial_prevalence * parameters["N"]))
     vals["IndI"][ids] = 1
@@ -60,7 +59,6 @@ def setup(initial_prevalence: float):
     sim_params["N_MDA"] = len(MDA_times)
     sim_params["N_Vaccines"] = len(vacc_times)
      
-
     return (
         vals,
         parameters,

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -70,6 +70,23 @@ def setup(initial_prevalence: float):
         VaccData,
     )
 
+def alterMDACoverage(MDAData, coverage):
+    """ update the coverage of each MDA for a run to be a given value.
+    Parameters
+    ----------
+    MDAData
+        A list of MDA's to be done with date and coverage of the MDA included. 
+        The coverage is given by the 4th value within each MDA of MDAData so we update the [3] position.
+    coverage    
+        The new coverage level for each MDA
+    Returns
+    -------
+    function
+        MDAData with updated coverage value
+    """
+    for MDA in MDAData:
+        MDA[3] = coverage
+    return MDAData
 
 def build_transmission_model(
         fitting_points: list[int],
@@ -118,16 +135,19 @@ def build_transmission_model(
                 timesim=sim_params["timesim"],
                 burnin=sim_params["burnin"],
                 demog=demog,
-                beta=beta,
+                beta=amisPars[0],
                 MDA_times=MDA_times,
-                MDAData=MDAData,
+                MDAData=alterMDACoverage(MDAData, amisPars[1]),
                 vacc_times=vacc_times,
                 VaccData=VaccData,
                 outputTimes=outputTimes,
                 index=i,
                 numpy_state=np.random.get_state(),
             )
-            for i, (seed, beta) in enumerate(zip(seeds, params))
+            # params now will have 2 columns, one for beta and one for coverage
+            # iterate over these, naming them amisPars, and amisPars[0] being beta
+            # amisPars[1] being the coverage value
+            for i, (seed, amisPars) in enumerate(zip(seeds, params))
         )
         # Get the prevalence from the returned values dictionary
         # This is an exemple of post-processing extracting prevalence among

--- a/trachoma_fitting.R
+++ b/trachoma_fitting.R
@@ -17,7 +17,17 @@ density_function <- function(parameters, log) {
 #' The "rprior" function that returns a matrix whose columns are the parameters
 #' and each row is a sample
 rnd_function <- function(num_samples) {
-    return(matrix(0.04, ncol = 1, nrow = num_samples, byrow = TRUE))
+    # set beta to just be 0.04 for each sample
+    beta <- rep(0.04, num_samples)
+  
+    # set coverage to be randomly generated numbers between 0 and 1
+    coverage <- runif(num_samples, min = 0, max = 1)
+    
+    # Combine the two columns to form the params matrix
+    result <- cbind(beta, coverage)
+    
+    return(result)
+
 }
 
 prior <- list("dprior" = density_function, "rprior" = rnd_function)


### PR DESCRIPTION
Edits to allow us to fit coverage within the AMIS framework.

This involves randomly generating values between 0 and 1 for coverage within the `rnd_function` function in the `trachoma_fitting.R` file.

Within the `amis_integration.py` file, we add a function to take in a coverage value and alter the `MDAData` variable to have this value as its coverage for all MDAs. 

I couldn't figure out a simple way to have named columns for the `params` variable imported from the `R` file (they were just unnamed `numpy.ndarray's`). Instead I changed the enumeration of `beta` within the `run_trachoma` function, to be `amisPars` which is a `numpy.ndarray` with 2 entries. The `[0]` entry is the beta and the `[1]` will be the coverage for that run.

Note: This will not currently run, as with the update Thibault made to reference the latest version of the trachoma repo, the `Set_inits` function requires `MDAData` as an input. I will raise another PR with this change.