### PR TITLE
give correct inputs to Set_inits

### DIFF
--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -48,17 +48,18 @@ def setup_vaccine(cov_filepath, burnin):
 
 
 def setup(initial_prevalence: float):
-    vals = Set_inits(parameters, demog, sim_params, np.random.get_state())
-    ids = random.sample(range(parameters["N"]), k=int(initial_prevalence * parameters["N"]))
-    vals["IndI"][ids] = 1
-    vals["T_latent"][ids] = vals["Ind_latent"][ids]
-    vals["No_Inf"][ids] = 1
-
     MDA_times, MDAData = setup_mda("scen2c.csv", sim_params["burnin"])
     vacc_times, VaccData = setup_vaccine("scen2c.csv", sim_params["burnin"])
     sim_params["N_MDA"] = len(MDA_times)
     sim_params["N_Vaccines"] = len(vacc_times)
 
+    vals = Set_inits(parameters, demog, sim_params, MDAData, np.random.get_state())
+    ids = random.sample(range(parameters["N"]), k=int(initial_prevalence * parameters["N"]))
+    vals["IndI"][ids] = 1
+    vals["T_latent"][ids] = vals["Ind_latent"][ids]
+    vals["No_Inf"][ids] = 1
+
+    
     return (
         vals,
         parameters,


### PR DESCRIPTION
With the updated version of the trachoma code now referenced, the `Set_intits` function requires `MDAData` as an input. 

Do this by calling `setup_mda` before `Set_inits` (rather than after) and adding `MDAData` to the inputs as required.