### PR TITLE
Pass seed value to model entry point

### DIFF
--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -142,7 +142,7 @@ def build_transmission_model(
                 VaccData=VaccData,
                 outputTimes=outputTimes,
                 index=i,
-                numpy_state=np.random.get_state(),
+                seed=seed,
             )
             # params now will have 2 columns, one for beta and one for coverage
             # iterate over these, naming them amisPars, and amisPars[0] being beta


### PR DESCRIPTION
This PR goes along with [ntd-model-trachoma#61](https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma/pull/61).

This should ensure that each instance of the `run_single_simulation` function use the seed provided by the AMIS calling function, whether the function instances are executed within the same Python process or not.

Note that the initial population state (e.g. infected individuals, age distribution, treatment probability) is the same across all instances of `run_single_simulation`. Therefore prevalence values will remain equal or similar over the first few iterations (weeks), before the trajectories separate between instances thanks to differences in propagation/treatment. This is the behaviour implemented in previous trachoma/AMIS integrations, where the initial age distribution and initial infection were the same across AMIS member simulations (see for instance [`init_ages`](https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma/blob/be8102b23aa3272f16f119e3283f755aa7b794d5/trachoma/trachoma_functions.py#L301) or [`seed_infection`](https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma/blob/be8102b23aa3272f16f119e3283f755aa7b794d5/trachoma/trachoma_functions.py#L281) functions).

If this behaviour is not expected any more, and each instance much start from a different, random initial state, then it would be up to the model entry point `run_single_simulation` to generate this state, instead of expecting it as a parameter `pickleData`.