### PR TITLE
Ensure the seed is used to produce matching results

### DIFF
--- a/tests/test_amis_integration.py
+++ b/tests/test_amis_integration.py
@@ -23,9 +23,6 @@ def test_running_twice_with_different_seed_produces_different_result_at_first_we
     assert result[0][0] != result[1][0]
 
 
-@pytest.mark.skip(
-    reason="When running with multiple cores, the same state is used for each process"
-)
 def test_running_twice_with_different_seed_produces_different_result_after_10_weeks():
     transmission_model = amis_integration.build_transmission_model(
         fitting_points=[10], initial_infect_frac=0.5, num_cores=2
@@ -37,14 +34,12 @@ def test_running_twice_with_different_seed_produces_different_result_after_10_we
 @pytest.mark.skip(reason="This can fail as sometimes the two models will not diverge")
 def test_running_twice_with_different_seed_produces_different_result_after_10_weeks_single_core():
     transmission_model = amis_integration.build_transmission_model(
-        fitting_points=[10], initial_infect_frac=0.5, num_cores=1
+        fitting_points=[100], initial_infect_frac=0.5, num_cores=1
     )
     result = transmission_model(seeds=[1, 2], params=[(0.2, 0.4), (0.2, 0.4)], n_tims=0)
-    # This works only becuase the single core means the state is shared from one run to the next
     assert result[0][0] != result[1][0]
 
 
-@pytest.mark.skip(reason="Seed is not used to run simulations")
 def test_running_twice_with_same_seed_produces_same_result_after_10_weeks():
     transmission_model = amis_integration.build_transmission_model(
         fitting_points=[10], initial_infect_frac=0.5, num_cores=1

--- a/tests/test_amis_integration.py
+++ b/tests/test_amis_integration.py
@@ -9,9 +9,7 @@ def test_build_transmission_model():
         fitting_points=[0, 1], initial_infect_frac=0.5, num_cores=1
     )
     result = transmission_model([1], [(0.2, 0.4)], 0)
-    # At the moment the seed is ignored so just check
-    # the shape of what is returned
-    assert np.shape(result) == (1, 2)
+    npt.assert_array_equal(result, [[0, 0.40625]])
 
 
 def test_running_twice_with_different_seed_produces_different_result_at_first_week():
@@ -19,7 +17,9 @@ def test_running_twice_with_different_seed_produces_different_result_at_first_we
         fitting_points=[1], initial_infect_frac=0.5, num_cores=1
     )
     result = transmission_model(seeds=[1, 2], params=[(0.2, 0.4), (0.2, 0.4)], n_tims=0)
-    assert result[0][0] != result[1][0]
+
+    assert result[0][0] == 0.40625
+    assert result[1][0] == 0.4722222222222222
 
 
 def test_running_twice_with_different_seed_produces_different_result_after_10_weeks():
@@ -27,15 +27,17 @@ def test_running_twice_with_different_seed_produces_different_result_after_10_we
         fitting_points=[10], initial_infect_frac=0.5, num_cores=2
     )
     result = transmission_model(seeds=[1, 2], params=[(0.2, 0.4), (0.2, 0.4)], n_tims=0)
-    assert result[0][0] != result[1][0]
+    assert result[0][0] == 0.78125
+    assert result[1][0] == 0.8
 
 
-def test_running_twice_with_different_seed_produces_different_result_after_100_weeks_single_core():
+def test_running_twice_with_different_seed_produces_different_result_after_10_weeks_single_core():
     transmission_model = amis_integration.build_transmission_model(
-        fitting_points=[100], initial_infect_frac=0.5, num_cores=1
+        fitting_points=[10], initial_infect_frac=0.5, num_cores=1
     )
     result = transmission_model(seeds=[1, 2], params=[(0.2, 0.4), (0.2, 0.4)], n_tims=0)
-    assert result[0][0] != result[1][0]
+    assert result[0][0] == 0.78125
+    assert result[1][0] == 0.8
 
 
 def test_running_twice_with_same_seed_produces_same_result_after_10_weeks():

--- a/tests/test_amis_integration.py
+++ b/tests/test_amis_integration.py
@@ -30,7 +30,7 @@ def test_running_twice_with_different_seed_produces_different_result_after_10_we
     assert result[0][0] != result[1][0]
 
 
-def test_running_twice_with_different_seed_produces_different_result_after_10_weeks_single_core():
+def test_running_twice_with_different_seed_produces_different_result_after_100_weeks_single_core():
     transmission_model = amis_integration.build_transmission_model(
         fitting_points=[100], initial_infect_frac=0.5, num_cores=1
     )

--- a/tests/test_amis_integration.py
+++ b/tests/test_amis_integration.py
@@ -11,6 +11,7 @@ def test_build_transmission_model():
     )
     result = transmission_model([1], [(0.2, 0.4)], 0)
     npt.assert_array_equal(result, [[0, 0.40625]])
+    assert isinstance(result, np.ndarray)
 
 
 def test_running_twice_with_different_seed_produces_different_result_at_first_week():

--- a/tests/test_amis_integration.py
+++ b/tests/test_amis_integration.py
@@ -14,7 +14,6 @@ def test_build_transmission_model():
     assert np.shape(result) == (1, 2)
 
 
-@pytest.mark.skip(reason="Seed is not used in setup inits")
 def test_running_twice_with_different_seed_produces_different_result_at_first_week():
     transmission_model = amis_integration.build_transmission_model(
         fitting_points=[1], initial_infect_frac=0.5, num_cores=1
@@ -31,7 +30,6 @@ def test_running_twice_with_different_seed_produces_different_result_after_10_we
     assert result[0][0] != result[1][0]
 
 
-@pytest.mark.skip(reason="This can fail as sometimes the two models will not diverge")
 def test_running_twice_with_different_seed_produces_different_result_after_10_weeks_single_core():
     transmission_model = amis_integration.build_transmission_model(
         fitting_points=[100], initial_infect_frac=0.5, num_cores=1

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -46,7 +46,6 @@ def setup_vaccine(cov_filepath, burnin):
     vacc_times = get_Intervention_times(Vaccine_dates, START_DATE, burnin)
     return vacc_times, VaccData
 
-
 def setup(initial_prevalence: float):
     MDA_times, MDAData = setup_mda("scen2c.csv", sim_params["burnin"])
     vacc_times, VaccData = setup_vaccine("scen2c.csv", sim_params["burnin"])
@@ -169,4 +168,5 @@ def build_transmission_model(
                 ]
             )
         )
+
     return run_trachoma

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -53,7 +53,9 @@ def setup(initial_prevalence: float):
     sim_params["N_Vaccines"] = len(vacc_times)
 
     vals = Set_inits(parameters, demog, sim_params, MDAData, np.random.get_state())
-    ids = random.sample(range(parameters["N"]), k=int(initial_prevalence * parameters["N"]))
+    ids = np.random.choice(
+        range(parameters["N"]), int(initial_prevalence * parameters["N"]), replace=False
+    )
     vals["IndI"][ids] = 1
     vals["T_latent"][ids] = vals["Ind_latent"][ids]
     vals["No_Inf"][ids] = 1

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -125,24 +125,29 @@ def build_transmission_model(
         sim_params['burnin'],
     )
 
+    def do_single_run(seed, beta, coverage, i):
+        np.random.seed(seed)
+        random_state = np.random.get_state()
+        return run_single_simulation(
+            pickleData=copy.deepcopy(init_vals),
+            params=parameters,
+            timesim=sim_params["timesim"],
+            burnin=sim_params["burnin"],
+            demog=demog,
+            beta=beta,
+            MDA_times=MDA_times,
+            MDAData=alterMDACoverage(MDAData, coverage),
+            vacc_times=vacc_times,
+            VaccData=VaccData,
+            outputTimes=outputTimes,
+            index=i,
+            numpy_state=random_state,
+        )
+
     def run_trachoma(seeds, params, n_tims):
         results: list[tuple[dict, list]]
         results = Parallel(n_jobs=num_cores)(
-            delayed(run_single_simulation)(
-                pickleData=copy.deepcopy(init_vals),
-                params=parameters,
-                timesim=sim_params["timesim"],
-                burnin=sim_params["burnin"],
-                demog=demog,
-                beta=amisPars[0],
-                MDA_times=MDA_times,
-                MDAData=alterMDACoverage(MDAData, amisPars[1]),
-                vacc_times=vacc_times,
-                VaccData=VaccData,
-                outputTimes=outputTimes,
-                index=i,
-                numpy_state=np.random.get_state(),
-            )
+            delayed(do_single_run)(seed, beta=amisPars[0], coverage=amisPars[1], i=i)
             # params now will have 2 columns, one for beta and one for coverage
             # iterate over these, naming them amisPars, and amisPars[0] being beta
             # amisPars[1] being the coverage value

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -52,16 +52,7 @@ def setup(initial_prevalence: float):
     sim_params["N_MDA"] = len(MDA_times)
     sim_params["N_Vaccines"] = len(vacc_times)
 
-    vals = Set_inits(parameters, demog, sim_params, MDAData, np.random.get_state())
-    ids = np.random.choice(
-        range(parameters["N"]), int(initial_prevalence * parameters["N"]), replace=False
-    )
-    vals["IndI"][ids] = 1
-    vals["T_latent"][ids] = vals["Ind_latent"][ids]
-    vals["No_Inf"][ids] = 1
-
     return (
-        vals,
         parameters,
         sim_params,
         demog,
@@ -70,6 +61,18 @@ def setup(initial_prevalence: float):
         vacc_times,
         VaccData,
     )
+
+
+def create_initial_population(initial_prevalence: float, MDAData):
+    vals = Set_inits(parameters, demog, sim_params, MDAData, np.random.get_state())
+    ids = np.random.choice(
+        range(parameters["N"]), int(initial_prevalence * parameters["N"]), replace=False
+    )
+    vals["IndI"][ids] = 1
+    vals["T_latent"][ids] = vals["Ind_latent"][ids]
+    vals["No_Inf"][ids] = 1
+    return vals
+
 
 def alterMDACoverage(MDAData, coverage):
     """ update the coverage of each MDA for a run to be a given value.
@@ -111,7 +114,6 @@ def build_transmission_model(
         A function of three arguments (seeds, betavals, n_sims).
     """
     (
-        init_vals,
         parameters,
         sim_params,
         demog,
@@ -129,6 +131,7 @@ def build_transmission_model(
 
     def do_single_run(seed, beta, coverage, i):
         np.random.seed(seed)
+        init_vals = create_initial_population(initial_infect_frac, MDAData)
         random_state = np.random.get_state()
         return run_single_simulation(
             pickleData=copy.deepcopy(init_vals),

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -46,7 +46,8 @@ def setup_vaccine(cov_filepath, burnin):
     vacc_times = get_Intervention_times(Vaccine_dates, START_DATE, burnin)
     return vacc_times, VaccData
 
-def setup(initial_prevalence: float):
+
+def setup():
     MDA_times, MDAData = setup_mda("scen2c.csv", sim_params["burnin"])
     vacc_times, VaccData = setup_vaccine("scen2c.csv", sim_params["burnin"])
     sim_params["N_MDA"] = len(MDA_times)
@@ -121,7 +122,7 @@ def build_transmission_model(
         MDAData,
         vacc_times,
         VaccData,
-    ) = setup(initial_infect_frac)
+    ) = setup()
 
     outputTimes = get_Intervention_times(
         getOutputTimes(range(2019, 2041)),


### PR DESCRIPTION
Key changes:
 * seed is used to setup numpy random before calling the mode
 * Each run of the model inits its population rather than sharing a population - meaning the result can be consistent by seed.

I'm concerned that the `MDAData` is used to `create_initial_population` before applying the fitted coverage - @mattg3004 would you be able to see if that is important (and if it is a problem, ideally write a test that demonstrates the problem). I'm also a bit concerned we don't copy the MDA data before changing it - on a single thread this might get shared between runs.  