### PR TITLE
Disable survey and IHME

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">= 3.9"
 
 # For later when model is on PyPI
 dependencies = [
-  "trachoma@git+https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma",
+  "trachoma@git+https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma@addOptionToTurnSurveyAndIHMEOutputOff",
   "numpy<2.0"
 ]
 

--- a/tests/test_amis_integration.py
+++ b/tests/test_amis_integration.py
@@ -29,7 +29,7 @@ def test_running_twice_with_different_seed_produces_different_result_after_10_we
         fitting_points=[10], initial_infect_frac=0.5, num_cores=2
     )
     result = transmission_model(seeds=[1, 2], params=[(0.2, 0.4), (0.2, 0.4)], n_tims=0)
-    assert result[0][0] == 0.78125
+    assert result[0][0] == 0.7272727272727273
     assert result[1][0] == 0.8
 
 
@@ -38,7 +38,7 @@ def test_running_twice_with_different_seed_produces_different_result_after_10_we
         fitting_points=[10], initial_infect_frac=0.5, num_cores=1
     )
     result = transmission_model(seeds=[1, 2], params=[(0.2, 0.4), (0.2, 0.4)], n_tims=0)
-    assert result[0][0] == 0.78125
+    assert result[0][0] == 0.7272727272727273
     assert result[1][0] == 0.8
 
 
@@ -53,9 +53,7 @@ def test_running_twice_with_same_seed_produces_same_result_after_10_weeks():
 def test_running_with_modified_coverage_eliminates_disease_if_high():
     # This needs to be long enough after the first treatment that
     # all the diseased individuals have recovered
-    # Currently also note the first two treatments do not happen
-    # as the initial survey disables the treatment into week ~150
-    first_week_after_treatment = 500
+    first_week_after_treatment = 150
     transmission_model = amis_integration.build_transmission_model(
         fitting_points=[first_week_after_treatment], initial_infect_frac=1, num_cores=1
     )
@@ -67,7 +65,7 @@ def test_running_with_modified_coverage_eliminates_disease_if_high():
         seeds=[1, 1], params=[(0.4, 0.9999), (0.4, 0)], n_tims=0
     )
     assert result[0][0] == 0.0
-    assert result[1][0] == 0.9310344827586207
+    assert result[1][0] == 1.0
 
     # Currently the params are a mutable global so modifying them could effect other tests
     # so make sure to restore them

--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -148,6 +148,8 @@ def build_transmission_model(
             outputTimes=outputTimes,
             index=i,
             numpy_state=random_state,
+            doIHMEOutput=False,
+            doSurvey=False,
         )
 
     def run_trachoma(seeds, params, n_tims):


### PR DESCRIPTION
Depends on: 
- [ ] NTD-Modelling-Consortium/ntd-model-trachoma#62

This uses the modification in the linked PR to be able to turn off surveys and IHME output as these are not required for fitting. Indeed, these cause issues as the MDA should happen regardless of what a simulated survey says. 