### PR TITLE
point to main: option to turn off survey is merged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">= 3.9"
 
 # For later when model is on PyPI
 dependencies = [
-  "trachoma@git+https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma@addOptionToTurnSurveyAndIHMEOutputOff",
+  "trachoma@git+https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma",
   "numpy<2.0"
 ]
 


### PR DESCRIPTION
the ability to turn off surveys in the trachoma repo is now merged to main, so point dependencies for this repo at main and not the branch with this ability to turn surveys off in it