### PR TITLE
Auto select lockfile and tweak installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,20 @@ simulation from the AMIS loop to compute fitted parameters.
 
 ## Installation
 
-Start with creating a Python virtual environment to install the
-[NTDMC trachoma model](https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma) into:
+Start with creating a Python virtual environment and activating it:
 
 ```shell
 python3 -m venv trachoma-venv
 source trachoma-venv/bin/activate
-pip install git+https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma.git@master
-cd ntd-model-trachoma/
-(trachoma-venv) pip install .
 ```
-In the same virtual environment, install the present AMIS integration
-package:
+
+With the virtual environment activated, install the present AMIS
+integration package:
 
 ```shell
 git clone https://github.com/NTD-Modelling-Consortium/trachoma-amis-integration.git
 cd trachoma-amis-integration/
-(trachoma-venv) pip install .
+pip install .
 ```
 
 Finally, install R dependencies:

--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ cd trachoma-amis-integration/
 
 Finally, install R dependencies:
 
-1. Launch a R session `R`
-2. Create a R virtual environment `renv::init()`
-3. Install dependencies `renv::restore()`
+
+1. Ensure the dependencies are locked for the version of R you are
+  using, by running the `setup_r_env.R` script: `Rscript setup_r_env.R`.
+2. Launch a R session `R`
+3. Create a R virtual environment with `renv::init()`
+4. Install dependencies with `renv::restore()`
 
 ## Running
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 
 requires-python = ">= 3.9"
 
-# For later when model is on PyPI
 dependencies = [
   "trachoma@git+https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma",
   "numpy"

--- a/setup_r_env.R
+++ b/setup_r_env.R
@@ -1,0 +1,12 @@
+version <- paste(version[c("major", "minor")], collapse = ".")
+underscored_version <- chartr(".", "_", version)
+file_name <- paste0("renv_", underscored_version, ".lock")
+if (file.exists(file_name)) {
+    if (file.exists("renv.lock")) {
+        file.remove("renv.lock")
+    }
+    file.copy(file_name, "renv.lock")
+    renv::restore()
+} else {
+    print(paste("No renv lock file for R", version))
+}


### PR DESCRIPTION
A small PR that adds a script to select the correct lock file according to the host R version. Taken from [run-sch/setup_r_env.R](https://github.com/NTD-Modelling-Consortium/run-sch/blob/main/setup_r_env.R).

This also removes the instruction to install the trachoma model manually, since it is listed in `pyproject.toml` file using the github URL and will be installed automatically when installing the integration package.