### PR TITLE
Specify coverage data from the command line

### DIFF
--- a/trachoma_amis/amis_integration.py
+++ b/trachoma_amis/amis_integration.py
@@ -33,23 +33,31 @@ def set_start_date(datestr: str):
         raise ValueError(msg)
 
 
-def setup_mda(cov_filepath, burnin):
-    MDAData = readPlatformData(cov_filepath, "MDA")
+def setup_mda(cov_filepath, burnin, data_path):
+    MDAData = readPlatformData(cov_filepath, "MDA", data_path)
     MDA_dates = getInterventionDates(MDAData)
     MDA_times = get_Intervention_times(MDA_dates, START_DATE, burnin)
     return MDA_times, MDAData
 
 
-def setup_vaccine(cov_filepath, burnin):
-    VaccData = readPlatformData(cov_filepath, "Vaccine")
+def setup_vaccine(cov_filepath, burnin, data_path):
+    VaccData = readPlatformData(cov_filepath, "Vaccine", data_path)
     Vaccine_dates = getInterventionDates(VaccData)
     vacc_times = get_Intervention_times(Vaccine_dates, START_DATE, burnin)
     return vacc_times, VaccData
 
 
-def setup():
-    MDA_times, MDAData = setup_mda("scen2c.csv", sim_params["burnin"])
-    vacc_times, VaccData = setup_vaccine("scen2c.csv", sim_params["burnin"])
+def setup(mda_coverage_filename, vaccine_coverage_filename, data_path):
+    MDA_times, MDAData = setup_mda(
+        mda_coverage_filename,
+        sim_params["burnin"],
+        data_path,
+    )
+    vacc_times, VaccData = setup_vaccine(
+        vaccine_coverage_filename,
+        sim_params["burnin"],
+        data_path,
+    )
     sim_params["N_MDA"] = len(MDA_times)
     sim_params["N_Vaccines"] = len(vacc_times)
 
@@ -80,9 +88,9 @@ def alterMDACoverage(MDAData, coverage):
     Parameters
     ----------
     MDAData
-        A list of MDA's to be done with date and coverage of the MDA included. 
+        A list of MDA's to be done with date and coverage of the MDA included.
         The coverage is given by the 4th value within each MDA of MDAData so we update the [3] position.
-    coverage    
+    coverage
         The new coverage level for each MDA
     Returns
     -------
@@ -96,7 +104,10 @@ def alterMDACoverage(MDAData, coverage):
 def build_transmission_model(
         fitting_points: list[int],
         initial_infect_frac=0.01,
-        num_cores=-2
+        num_cores=-2,
+        mda_coverage_filename,
+        vaccine_coverage_filename,
+        coverage_data_path=None,
 ):
     """Create a closure for the AMIS to run the trachoma model.
 
@@ -122,7 +133,11 @@ def build_transmission_model(
         MDAData,
         vacc_times,
         VaccData,
-    ) = setup()
+    ) = setup(
+        mda_coverage_filename,
+        vaccine_coverage_filename,
+        coverage_data_path,
+    )
 
     outputTimes = get_Intervention_times(
         getOutputTimes(range(2019, 2041)),

--- a/trachoma_fitting.R
+++ b/trachoma_fitting.R
@@ -37,8 +37,23 @@ weeks_indices <- c(0L, 5199L)
 initial_infect = 0.01
 num_cores = 1L
 
+args = commandArgs(trailingOnly=TRUE)
+# test if there is at least one argument: if not, return an error
+if (length(args)==0) {
+  stop("At least two arguments must be supplied", call.=FALSE)
+} else if (length(args)==2) {
+  # No data location provided
+  args[3] <- NULL
+}
+
+mda_coverage_data_filename <- args[1]
+vaccine_coverage_data_filename <- args[2]
+coverage_data_path <- args[3]
 model_func <- amis_int_mod$build_transmission_model(
-    weeks_indices, initial_infect, num_cores
+    weeks_indices, initial_infect, num_cores,
+    mda_coverage_data_filename,
+    vaccine_coverage_data_filename,
+    coverage_data_path
 )
 
 error_function <- function(e) {


### PR DESCRIPTION
This builds on top of https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma/pull/66

The main script `trachoma_fitting.R` can be run with 3 command line arguments

1. The name of the MDA coverage data file
2. The name of the vaccination coverage data file
3. A path to the directory holding the files

Argument (3) is optional.  If not provided, behavior falls back to looking for files in the trachoma package's `data/` directory.

Example:
```
Rscript trachoma_fitting.R scen2c.csv scen3c.csv /path/to/data
```

In terms of implementation, the cli args are parsed from the main R script using `commandArgs`, then passed to `build_transmission_model`. They eventually trickle down to the `readPlatformData` function from the trachoma model.