### PR TITLE
use main branch of trachoma

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">= 3.9"
 
 # For later when model is on PyPI
 dependencies = [
-  "trachoma@git+https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma@addOptionToTurnSurveyAndIHMEOutputOff",
+  "trachoma@git+https://github.com/NTD-Modelling-Consortium/ntd-model-trachoma",
   "numpy<2.0"
 ]
 


### PR DESCRIPTION
branch used was set to @addOptionToTurnSurveyAndIHMEOutputOff, which is an old branch which has been merged into the main branch of trachoma code. delete this, so that the main branch is used.